### PR TITLE
Fixes clipboard issues experienced on Ubuntu 24.04/X11 and added the verbose flag. Not a pretty commit.

### DIFF
--- a/crates/whis-cli/src/args.rs
+++ b/crates/whis-cli/src/args.rs
@@ -6,6 +6,10 @@ use clap::{Parser, Subcommand};
 #[command(about = "Voice-to-text CLI using OpenAI Whisper or Mistral Voxtral")]
 #[command(after_help = "Run 'whis' without arguments to record once (press Enter to stop).")]
 pub struct Cli {
+    /// Enable verbose output for debugging (audio device, FFmpeg, clipboard, etc.)
+    #[arg(short, long, global = true)]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/crates/whis-cli/src/main.rs
+++ b/crates/whis-cli/src/main.rs
@@ -7,9 +7,13 @@ mod service;
 
 use anyhow::Result;
 use clap::Parser;
+use whis_core::set_verbose;
 
 fn main() -> Result<()> {
     let cli = args::Cli::parse();
+
+    // Enable verbose logging if requested
+    set_verbose(cli.verbose);
 
     match cli.command {
         Some(args::Commands::Listen { hotkey }) => commands::listen::run(hotkey),

--- a/crates/whis-core/src/clipboard.rs
+++ b/crates/whis-core/src/clipboard.rs
@@ -3,9 +3,22 @@ use arboard::Clipboard;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
+use crate::verbose;
+
 /// Check if running inside a Flatpak sandbox
 fn is_flatpak() -> bool {
     std::path::Path::new("/.flatpak-info").exists()
+}
+
+/// Get the current session type (x11, wayland, or unknown)
+fn session_type() -> &'static str {
+    std::env::var("XDG_SESSION_TYPE")
+        .map(|s| match s.as_str() {
+            "x11" => "x11",
+            "wayland" => "wayland",
+            _ => "unknown",
+        })
+        .unwrap_or("unknown")
 }
 
 /// Copy to clipboard using bundled wl-copy
@@ -14,6 +27,8 @@ fn is_flatpak() -> bool {
 /// This is required because GNOME/Mutter does not implement the wlr-data-control
 /// Wayland protocol that arboard's wayland-data-control feature requires.
 fn copy_via_wl_copy(text: &str) -> Result<()> {
+    crate::verbose!("Using wl-copy for clipboard (Flatpak environment)");
+
     let mut child = Command::new("wl-copy")
         .stdin(Stdio::piped())
         .spawn()
@@ -30,21 +45,69 @@ fn copy_via_wl_copy(text: &str) -> Result<()> {
         anyhow::bail!("wl-copy exited with non-zero status");
     }
 
+    crate::verbose!("wl-copy succeeded");
+    Ok(())
+}
+
+/// Copy to clipboard using xclip (for X11)
+///
+/// arboard has issues on some X11 setups where it reports success but
+/// doesn't actually set the clipboard. xclip is more reliable.
+fn copy_via_xclip(text: &str) -> Result<()> {
+    crate::verbose!("Using xclip for clipboard");
+
+    let mut child = Command::new("xclip")
+        .args(["-selection", "clipboard"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("Failed to spawn xclip. Install it with: sudo apt install xclip")?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text.as_bytes())
+            .context("Failed to write to xclip")?;
+    }
+
+    let status = child.wait().context("Failed to wait for xclip")?;
+    if !status.success() {
+        anyhow::bail!("xclip exited with non-zero status");
+    }
+
+    crate::verbose!("xclip succeeded");
     Ok(())
 }
 
 pub fn copy_to_clipboard(text: &str) -> Result<()> {
+    crate::verbose!("Copying to clipboard: {} chars", text.len());
+    crate::verbose!("Session type: {}", session_type());
+    crate::verbose!("Is Flatpak: {}", is_flatpak());
+
+    if verbose::is_verbose() && !text.is_empty() {
+        // Show a preview of the text (first 100 chars)
+        let preview: String = text.chars().take(100).collect();
+        let suffix = if text.len() > 100 { "..." } else { "" };
+        crate::verbose!("Text preview: \"{preview}{suffix}\"");
+    }
+
     // In Flatpak, use bundled wl-copy directly.
     // This is necessary because GNOME doesn't support wlr-data-control protocol.
     if is_flatpak() {
         return copy_via_wl_copy(text);
     }
 
-    // Standard approach for non-Flatpak environments
+    // On X11, use xclip which is more reliable than arboard
+    if session_type() == "x11" {
+        return copy_via_xclip(text);
+    }
+
+    // Standard approach using arboard (Wayland non-Flatpak)
+    crate::verbose!("Using arboard for clipboard");
     let mut clipboard = Clipboard::new().context("Failed to access clipboard")?;
     clipboard
         .set_text(text)
         .context("Failed to copy text to clipboard")?;
+
+    crate::verbose!("Clipboard set successfully via arboard");
 
     Ok(())
 }

--- a/crates/whis-core/src/lib.rs
+++ b/crates/whis-core/src/lib.rs
@@ -3,9 +3,11 @@ pub mod clipboard;
 pub mod config;
 pub mod settings;
 pub mod transcribe;
+pub mod verbose;
 
 pub use audio::{AudioChunk, AudioRecorder, RecordingData, RecordingOutput};
 pub use clipboard::copy_to_clipboard;
 pub use config::TranscriptionProvider;
 pub use settings::Settings;
 pub use transcribe::{parallel_transcribe, transcribe_audio, ChunkTranscription};
+pub use verbose::set_verbose;

--- a/crates/whis-core/src/verbose.rs
+++ b/crates/whis-core/src/verbose.rs
@@ -1,0 +1,35 @@
+//! Verbose logging support for debugging whis operations.
+//!
+//! Use `set_verbose(true)` to enable verbose output, then use `verbose!()` macro
+//! or `log()` function to print debug information.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static VERBOSE: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable verbose logging
+pub fn set_verbose(enabled: bool) {
+    VERBOSE.store(enabled, Ordering::SeqCst);
+}
+
+/// Check if verbose logging is enabled
+pub fn is_verbose() -> bool {
+    VERBOSE.load(Ordering::SeqCst)
+}
+
+/// Log a message if verbose mode is enabled
+pub fn log(message: &str) {
+    if is_verbose() {
+        eprintln!("[verbose] {}", message);
+    }
+}
+
+/// Log a formatted message if verbose mode is enabled
+#[macro_export]
+macro_rules! verbose {
+    ($($arg:tt)*) => {
+        if $crate::verbose::is_verbose() {
+            eprintln!("[verbose] {}", format!($($arg)*));
+        }
+    };
+}


### PR DESCRIPTION
This is the result of a claude session to fix an issue of nothing appearing on my clipboard.

It does two things:

1. Adds a --verbose flag and a bunch of claude generated messages everywhere.
2. Adds a workaround for a perceived bug in arboard on my setup, and uses xclip instead.

I'm on Ubuntu 24.04/X11 (i3wm if that makes a difference to clipboard managers).

I haven't verified that xclip is a good solution. I haven't checked in case the arboard issue is trivial. I haven't checked the veracity of any of the verbose logs.

This is pretty low effort on my part.

But it fixes it for me.