### PR TITLE
Feature (desktop): Add --start-in-tray CLI option for background startup

### DIFF
--- a/crates/whis-desktop/src/lib.rs
+++ b/crates/whis-desktop/src/lib.rs
@@ -7,10 +7,10 @@ mod window;
 use tauri::Manager;
 use whis_core::Settings;
 
-pub fn run() {
+pub fn run(start_in_tray: bool) {
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
-        .setup(|app| {
+        .setup(move |app| {
             // Load settings from disk
             let loaded_settings = Settings::load();
 
@@ -32,8 +32,10 @@ pub fn run() {
             // Start IPC listener for --toggle CLI commands
             shortcuts::start_ipc_listener(app.handle().clone());
 
-            // Always show main window on startup
-            window::show_main_window(app)?;
+            // Only show main window if NOT starting in tray
+            if !start_in_tray {
+                window::show_main_window(app)?;
+            }
 
             Ok(())
         })

--- a/crates/whis-desktop/src/main.rs
+++ b/crates/whis-desktop/src/main.rs
@@ -51,10 +51,11 @@ fn main() {
         println!("    whis-desktop [OPTIONS]");
         println!();
         println!("OPTIONS:");
-        println!("    -t, --toggle    Toggle recording in running instance");
-        println!("        --install   Install desktop file and icons for app menu");
-        println!("        --uninstall Remove desktop file and icons");
-        println!("    -h, --help      Print this help message");
+        println!("    -t, --toggle          Toggle recording in running instance");
+        println!("        --install         Install desktop file and icons for app menu");
+        println!("        --uninstall       Remove desktop file and icons");
+        println!("        --start-in-tray   Launch application in background without window");
+        println!("    -h, --help            Print this help message");
         println!();
         println!("GLOBAL SHORTCUT:");
         println!("    Ctrl+Alt+W      Toggle recording (Linux: X11/Portal)");
@@ -73,8 +74,11 @@ fn main() {
         eprintln!("   Then launch from your app menu.\n");
     }
 
+    // Check for start-in-tray flag
+    let start_in_tray = args.contains(&"--start-in-tray".to_string());
+
     // Start the GUI application
-    whis_desktop::run();
+    whis_desktop::run(start_in_tray);
 }
 
 /// Check if we're running as an AppImage launched from a terminal


### PR DESCRIPTION
**Description:**
This PR adds a new CLI argument `--start-in-tray` that allows Whis to start directly into the system tray without opening the main window.

**Problem:**
Currently, when configuring Whis to start automatically on Linux (e.g., via a systemd user service or autostart entry), the main window always opens on boot. Users who want the application to run silently in the background waiting for the global hotkey have to manually close the window every time they log in.

**Solution:**

1. Modified `whis_desktop::run()` in `lib.rs` to accept a `start_in_tray` boolean.
2. Made the `window::show_main_window(app)` call conditional based on this flag.
3. Updated `main.rs` to parse the `--start-in-tray` argument.
4. Updated the `--help` output to document the new option.

**Usage:**

```bash
whis-desktop --start-in-tray
```

**Testing:**

* [x] Verified normal startup (window appears).
* [x] Verified startup with `--start-in-tray` (app runs in background, tray icon appears, window hidden).
* [x] Verified `--help` output displays the new option correctly.
* [x] Performed `just lint-desktop` and `just ftm-desktop` checks.