### PR TITLE
fix(desktop): enforce single instance & fix tray init order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5941,6 +5941,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd707f8c86b4e3004e2c141fa24351f1909ba40ce1b8437e30d5ed5277dd3710"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.17",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-plugin-store"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7149,7 +7164,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whis"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7168,7 +7183,7 @@ dependencies = [
 
 [[package]]
 name = "whis-core"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -7197,7 +7212,7 @@ dependencies = [
 
 [[package]]
 name = "whis-desktop"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -7211,6 +7226,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tokio",
  "whis-core",
  "zbus",
@@ -7218,7 +7234,7 @@ dependencies = [
 
 [[package]]
 name = "whis-mobile"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -7234,7 +7250,7 @@ dependencies = [
 
 [[package]]
 name = "whis-screenshots"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/whis-desktop/Cargo.toml
+++ b/crates/whis-desktop/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-global-shortcut = "2.3"
 tauri-plugin-process = "2.3"
 futures-util = "0.3"
 image = "0.25"
+tauri-plugin-single-instance = "2.3.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/crates/whis-desktop/src/window.rs
+++ b/crates/whis-desktop/src/window.rs
@@ -1,8 +1,8 @@
-use tauri::{WebviewUrl, WebviewWindowBuilder};
+use tauri::{AppHandle, WebviewUrl, WebviewWindowBuilder};
 
 /// Show the main window when tray is not available
 /// This provides a fallback UI for tray-less desktop environments
-pub fn show_main_window(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+pub fn show_main_window(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let window = WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
         .title("Whis")
         .inner_size(600.0, 400.0)


### PR DESCRIPTION
**Description:**
This PR introduces the `tauri-plugin-single-instance` to prevent multiple application processes from running simultaneously and fixes an initialization race condition in `lib.rs`.

**Problems Solved:**

1. **Multiple Instances:** Previously, launching the application via the system menu while it was already running (e.g., in the tray) would start a second process and a second tray icon.
2. **Tray/State Race Condition:** Logs showed "Menu item not found" errors during startup because `setup_tray` was called before `AppState` was fully initialized.
3. **UX Issue:** Clicking the application icon when the app was already running in the background did not bring the window to the foreground.

**Changes:**

* **Dependency:** Added `tauri-plugin-single-instance`.
* **Refactor (`lib.rs`):** Reordered initialization: `AppState` is now initialized *before* `tray::setup_tray`.
* **Refactor (`window.rs`):** Updated `show_main_window` signature to accept `&AppHandle` instead of `&App` to allow reuse within the single-instance closure.
* **Logic:** Implemented logic to detect a second launch attempt. If the second instance is launched without `--start-in-tray` (e.g., user click), the existing instance will create/show and focus the main window.

**Verification / Testing:**
Tested locally with a release build (`./target/release/whis-desktop`).

* [x] **Fresh Start (`--start-in-tray`):** Verified app starts silently in the background with tray icon, no window.
* [x] **Second Launch (No Args):** Verified that running the binary a second time (simulating a menu click) does **not** start a new process/icon, but instead opens/focuses the window of the first instance.
* [x] **Log Check:** Verified that "Menu item not found" errors are gone from the log output.
* [x] **Code Quality:** Passed `just fmt-desktop` and `just lint-desktop`.

**Note for Flatpak Maintainers:**
Since this introduces `tauri-plugin-single-instance` (which uses DBus for inter-process communication), the Flatpak manifest might need to expose the specific DBus name generated by the plugin (typically matching the app ID or `org.your.app.SingleInstance`) if the sandbox blocks it.
