### PR TITLE
feat(cli): add push-to-talk mode for direct hotkey

### DIFF
--- a/crates/whis-cli/src/commands/config.rs
+++ b/crates/whis-cli/src/commands/config.rs
@@ -23,6 +23,7 @@ const VALID_KEYS: &[&str] = &[
     "microphone-device",
     "cli-mode",
     "cli-key",
+    "cli-push-to-talk",
     "desktop-key",
     "vad",
     "vad-threshold",
@@ -249,6 +250,13 @@ fn set_config(key: &str, value: &str) -> Result<()> {
             settings.shortcuts.validate()?;
             println!("desktop-key = {}", value_trimmed);
         }
+        "cli-push-to-talk" => {
+            let enabled = value_trimmed
+                .parse::<bool>()
+                .context("Invalid value. Use 'true' or 'false'")?;
+            settings.shortcuts.cli_push_to_talk = enabled;
+            println!("cli-push-to-talk = {}", enabled);
+        }
         _ => unreachable!("Key validation should prevent this"),
     }
 
@@ -318,6 +326,7 @@ fn get_config(key: &str) -> Result<()> {
         "chunk-size" => println!("{}s", settings.ui.chunk_duration_secs),
         "cli-mode" => println!("{}", settings.shortcuts.cli_mode),
         "cli-key" => println!("{}", settings.shortcuts.cli_key),
+        "cli-push-to-talk" => println!("{}", settings.shortcuts.cli_push_to_talk),
         "desktop-key" => println!("{}", settings.shortcuts.desktop_key),
         _ => unreachable!("Key validation should prevent this"),
     }
@@ -421,6 +430,7 @@ fn show_all_settings() -> Result<()> {
     println!("[Shortcuts]");
     println!("cli-mode = {}", settings.shortcuts.cli_mode);
     println!("cli-key = {}", settings.shortcuts.cli_key);
+    println!("cli-push-to-talk = {}", settings.shortcuts.cli_push_to_talk);
     println!("desktop-key = {}", settings.shortcuts.desktop_key);
 
     println!();

--- a/crates/whis-cli/src/hotkey/mod.rs
+++ b/crates/whis-cli/src/hotkey/mod.rs
@@ -1,7 +1,9 @@
-//! Cross-platform hotkey support
+//! Cross-platform hotkey support (push-to-talk mode)
 //!
 //! - Linux/macOS: Uses rdev for keyboard grab (supports X11, Wayland, and macOS)
 //! - Windows: Uses global-hotkey crate (Tauri-maintained)
+//!
+//! Push-to-talk: Recording starts when hotkey is pressed, stops when released.
 
 use anyhow::Result;
 use std::sync::mpsc::Receiver;
@@ -16,13 +18,22 @@ mod windows;
 #[cfg(target_os = "windows")]
 use windows as platform;
 
+/// Hotkey events for push-to-talk mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HotkeyEvent {
+    /// Hotkey was pressed - start recording
+    Pressed,
+    /// Hotkey was released - stop recording
+    Released,
+}
+
 /// Opaque guard that keeps the hotkey listener alive
 #[allow(dead_code)]
 pub struct HotkeyGuard(platform::HotkeyGuard);
 
-/// Setup the hotkey listener.
-/// Returns a receiver for hotkey events and a guard that must be kept alive.
-pub fn setup(hotkey_str: &str) -> Result<(Receiver<()>, HotkeyGuard)> {
+/// Setup the hotkey listener for push-to-talk mode.
+/// Returns a receiver for hotkey press/release events and a guard that must be kept alive.
+pub fn setup(hotkey_str: &str) -> Result<(Receiver<HotkeyEvent>, HotkeyGuard)> {
     let (rx, guard) = platform::setup(hotkey_str)?;
     Ok((rx, HotkeyGuard(guard)))
 }

--- a/crates/whis-core/src/settings/shortcuts.rs
+++ b/crates/whis-core/src/settings/shortcuts.rs
@@ -84,6 +84,14 @@ pub struct ShortcutsSettings {
     /// Used by whis-desktop application.
     #[serde(default = "default_shortcut")]
     pub desktop_key: String,
+
+    /// Push-to-talk mode for CLI direct hotkey.
+    ///
+    /// When enabled, recording starts when the hotkey is pressed and stops
+    /// when released. When disabled (default), the hotkey toggles recording.
+    /// Only used when `cli_mode` is `direct`.
+    #[serde(default)]
+    pub cli_push_to_talk: bool,
 }
 
 impl Default for ShortcutsSettings {
@@ -92,6 +100,7 @@ impl Default for ShortcutsSettings {
             cli_mode: CliShortcutMode::default(),
             cli_key: default_shortcut(),
             desktop_key: default_shortcut(),
+            cli_push_to_talk: false,
         }
     }
 }

--- a/crates/whis-core/src/settings/store_adapter.rs
+++ b/crates/whis-core/src/settings/store_adapter.rs
@@ -22,6 +22,7 @@
 //! ollama_model          → services.ollama.model
 //! cli_mode              → shortcuts.cli_mode
 //! cli_key               → shortcuts.cli_key
+//! cli_push_to_talk      → shortcuts.cli_push_to_talk
 //! desktop_key           → shortcuts.desktop_key
 //! vad_enabled           → ui.vad.enabled
 //! vad_threshold         → ui.vad.threshold
@@ -124,6 +125,10 @@ impl Settings {
             settings.shortcuts.desktop_key = key.clone();
         }
 
+        if let Some(Value::Bool(ptt)) = map.get("cli_push_to_talk") {
+            settings.shortcuts.cli_push_to_talk = *ptt;
+        }
+
         if let Some(Value::Bool(enabled)) = map.get("vad_enabled") {
             settings.ui.vad.enabled = *enabled;
         }
@@ -203,6 +208,10 @@ impl Settings {
         map.insert(
             "desktop_key".to_string(),
             Value::String(self.shortcuts.desktop_key.clone()),
+        );
+        map.insert(
+            "cli_push_to_talk".to_string(),
+            Value::Bool(self.shortcuts.cli_push_to_talk),
         );
 
         map.insert("vad_enabled".to_string(), Value::Bool(self.ui.vad.enabled));

--- a/crates/whis-desktop/ui/src/stores/settings.ts
+++ b/crates/whis-desktop/ui/src/stores/settings.ts
@@ -75,6 +75,7 @@ function getDefaultSettings(): Settings {
     shortcuts: {
       cli_mode: 'system' as CliShortcutMode,
       cli_key: defaults.desktop_key,
+      cli_push_to_talk: false,
       desktop_key: defaults.desktop_key,
     },
     ui: {
@@ -201,6 +202,7 @@ async function load() {
     state.shortcuts = {
       cli_mode: settings.shortcuts?.cli_mode || 'system',
       cli_key: settings.shortcuts?.cli_key || defaults.desktop_key,
+      cli_push_to_talk: settings.shortcuts?.cli_push_to_talk ?? false,
       desktop_key: settings.shortcuts?.desktop_key || defaults.desktop_key,
     }
     state.ui = {

--- a/crates/whis-desktop/ui/src/types.ts
+++ b/crates/whis-desktop/ui/src/types.ts
@@ -52,6 +52,7 @@ export interface Settings {
   shortcuts: {
     cli_mode: CliShortcutMode
     cli_key: string
+    cli_push_to_talk: boolean
     desktop_key: string
   }
   ui: {


### PR DESCRIPTION
## Summary

Add optional push-to-talk behavior for CLI direct hotkey mode. When enabled, recording starts when the hotkey is pressed and stops when released. The default toggle behavior is preserved.

- Add cli-push-to-talk config option (whis config cli-push-to-talk true)
- Extend hotkey system to emit press/release events
- Service handles both toggle and push-to-talk modes
- Update settings store and TypeScript types for desktop UI

## Related Issues

Closes #18
