### PR TITLE
fix(cli): replace polling loop with event-driven select

### DIFF
--- a/crates/whis-cli/src/hotkey/mod.rs
+++ b/crates/whis-cli/src/hotkey/mod.rs
@@ -6,7 +6,7 @@
 //! Push-to-talk: Recording starts when hotkey is pressed, stops when released.
 
 use anyhow::Result;
-use std::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod unix_like;
@@ -33,7 +33,7 @@ pub struct HotkeyGuard(platform::HotkeyGuard);
 
 /// Setup the hotkey listener for push-to-talk mode.
 /// Returns a receiver for hotkey press/release events and a guard that must be kept alive.
-pub fn setup(hotkey_str: &str) -> Result<(Receiver<HotkeyEvent>, HotkeyGuard)> {
+pub fn setup(hotkey_str: &str) -> Result<(UnboundedReceiver<HotkeyEvent>, HotkeyGuard)> {
     let (rx, guard) = platform::setup(hotkey_str)?;
     Ok((rx, HotkeyGuard(guard)))
 }

--- a/crates/whis-cli/src/hotkey/unix_like.rs
+++ b/crates/whis-cli/src/hotkey/unix_like.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use std::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 use whis_core::hotkey::Hotkey;
 
 use super::HotkeyEvent;
@@ -21,9 +21,9 @@ use whis_core::hotkey::lock_or_recover;
 
 pub struct HotkeyGuard;
 
-pub fn setup(hotkey_str: &str) -> Result<(Receiver<HotkeyEvent>, HotkeyGuard)> {
+pub fn setup(hotkey_str: &str) -> Result<(UnboundedReceiver<HotkeyEvent>, HotkeyGuard)> {
     let hotkey = Hotkey::parse(hotkey_str).map_err(|e| anyhow::anyhow!(e))?;
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let tx_release = tx.clone();
 
     std::thread::spawn(move || {

--- a/crates/whis-cli/src/hotkey/windows.rs
+++ b/crates/whis-cli/src/hotkey/windows.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState, hotkey::HotKey};
-use std::sync::mpsc::Receiver;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use super::HotkeyEvent;
 
@@ -10,7 +10,7 @@ pub struct HotkeyGuard {
     _manager: GlobalHotKeyManager,
 }
 
-pub fn setup(hotkey_str: &str) -> Result<(Receiver<HotkeyEvent>, HotkeyGuard)> {
+pub fn setup(hotkey_str: &str) -> Result<(UnboundedReceiver<HotkeyEvent>, HotkeyGuard)> {
     let converted = convert_to_global_hotkey_format(hotkey_str)?;
     let hotkey: HotKey = converted
         .parse()
@@ -30,7 +30,7 @@ pub fn setup(hotkey_str: &str) -> Result<(Receiver<HotkeyEvent>, HotkeyGuard)> {
 
     let receiver = GlobalHotKeyEvent::receiver().clone();
     let hotkey_id = hotkey.id();
-    let (tx, rx) = std::sync::mpsc::channel();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
     std::thread::spawn(move || {
         loop {

--- a/crates/whis-cli/src/ipc.rs
+++ b/crates/whis-cli/src/ipc.rs
@@ -21,12 +21,12 @@
 //! - `IpcConnection` - Individual client connection handler
 
 use anyhow::{Context, Result};
-use interprocess::local_socket::{
-    GenericFilePath, ListenerNonblockingMode, ListenerOptions, ToFsName, prelude::*,
-};
+use interprocess::local_socket::{GenericFilePath, ListenerOptions, ToFsName, prelude::*};
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::mpsc;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum IpcMessage {
@@ -58,10 +58,13 @@ fn socket_name() -> String {
 }
 
 /// IPC Server for the background service
+///
+/// Uses a background thread to accept connections and sends them through a channel,
+/// enabling event-driven async operation without polling.
 pub struct IpcServer {
-    listener: LocalSocketListener,
+    conn_rx: mpsc::UnboundedReceiver<IpcConnection>,
     #[cfg(unix)]
-    socket_path: PathBuf,
+    socket_path: Arc<PathBuf>,
 }
 
 impl IpcServer {
@@ -70,10 +73,11 @@ impl IpcServer {
 
         // On Unix, save socket path for cleanup and remove old socket if it exists
         #[cfg(unix)]
-        let socket_path = PathBuf::from(&name_str);
+        let socket_path = Arc::new(PathBuf::from(&name_str));
         #[cfg(unix)]
         if socket_path.exists() {
-            std::fs::remove_file(&socket_path).context("Failed to remove old socket file")?;
+            std::fs::remove_file(socket_path.as_ref())
+                .context("Failed to remove old socket file")?;
         }
 
         let name = name_str
@@ -85,25 +89,36 @@ impl IpcServer {
             .create_sync()
             .context("Failed to create IPC listener")?;
 
-        // Set non-blocking mode for the listener
-        listener
-            .set_nonblocking(ListenerNonblockingMode::Both)
-            .context("Failed to set non-blocking mode")?;
+        // Create channel for connections
+        let (conn_tx, conn_rx) = mpsc::unbounded_channel();
+
+        // Spawn background thread to accept connections (blocking)
+        std::thread::spawn(move || {
+            loop {
+                match listener.accept() {
+                    Ok(stream) => {
+                        if conn_tx.send(IpcConnection { stream }).is_err() {
+                            break; // Receiver dropped, exit thread
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("IPC accept error: {e}");
+                        break;
+                    }
+                }
+            }
+        });
 
         Ok(Self {
-            listener,
+            conn_rx,
             #[cfg(unix)]
             socket_path,
         })
     }
 
-    /// Try to accept a new connection (non-blocking)
-    pub fn try_accept(&self) -> Result<Option<IpcConnection>> {
-        match self.listener.accept() {
-            Ok(stream) => Ok(Some(IpcConnection { stream })),
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+    /// Receive the next connection asynchronously
+    pub async fn accept(&mut self) -> Option<IpcConnection> {
+        self.conn_rx.recv().await
     }
 }
 
@@ -112,7 +127,7 @@ impl Drop for IpcServer {
         // On Unix, clean up the socket file
         #[cfg(unix)]
         {
-            let _ = std::fs::remove_file(&self.socket_path);
+            let _ = std::fs::remove_file(self.socket_path.as_ref());
         }
         // On Windows, named pipes are cleaned up automatically by the OS
     }

--- a/crates/whis-cli/src/ipc.rs
+++ b/crates/whis-cli/src/ipc.rs
@@ -16,7 +16,7 @@
 //!
 //! # Components
 //!
-//! - `IpcServer` - Non-blocking listener for the service
+//! - `IpcServer` - Event-driven async listener for the service
 //! - `IpcClient` - Blocking client for CLI commands
 //! - `IpcConnection` - Individual client connection handler
 
@@ -25,7 +25,6 @@ use interprocess::local_socket::{GenericFilePath, ListenerOptions, ToFsName, pre
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -64,7 +63,7 @@ fn socket_name() -> String {
 pub struct IpcServer {
     conn_rx: mpsc::UnboundedReceiver<IpcConnection>,
     #[cfg(unix)]
-    socket_path: Arc<PathBuf>,
+    socket_path: PathBuf,
 }
 
 impl IpcServer {
@@ -73,11 +72,10 @@ impl IpcServer {
 
         // On Unix, save socket path for cleanup and remove old socket if it exists
         #[cfg(unix)]
-        let socket_path = Arc::new(PathBuf::from(&name_str));
+        let socket_path = PathBuf::from(&name_str);
         #[cfg(unix)]
         if socket_path.exists() {
-            std::fs::remove_file(socket_path.as_ref())
-                .context("Failed to remove old socket file")?;
+            std::fs::remove_file(&socket_path).context("Failed to remove old socket file")?;
         }
 
         let name = name_str
@@ -102,8 +100,9 @@ impl IpcServer {
                         }
                     }
                     Err(e) => {
+                        // Log error but continue accepting - some errors may be transient
+                        // (e.g., too many open files, interrupted syscall)
                         eprintln!("IPC accept error: {e}");
-                        break;
                     }
                 }
             }
@@ -127,7 +126,7 @@ impl Drop for IpcServer {
         // On Unix, clean up the socket file
         #[cfg(unix)]
         {
-            let _ = std::fs::remove_file(self.socket_path.as_ref());
+            let _ = std::fs::remove_file(self.socket_path.as_path());
         }
         // On Windows, named pipes are cleaned up automatically by the OS
     }

--- a/crates/whis-cli/src/service.rs
+++ b/crates/whis-cli/src/service.rs
@@ -27,19 +27,17 @@
 //!
 //! # Architecture
 //!
-//! - Polling loop checks IPC server + hotkey channel (non-blocking)
+//! - Event-driven loop using `tokio::select!` (no polling, zero CPU when idle)
 //! - Progressive transcription: audio chunks sent during recording
 //! - Post-processing and clipboard copy on completion
 
 use anyhow::{Context, Result};
-use std::sync::mpsc::Receiver;
 use std::sync::{Arc, Mutex};
-use tokio::time::sleep;
+use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::app::TranscriptionConfig;
 use crate::hotkey::HotkeyEvent;
 use crate::ipc::{IpcMessage, IpcResponse, IpcServer};
-use std::time::Duration;
 use whis_core::{
     AudioRecorder, DEFAULT_POST_PROCESSING_PROMPT, Settings, TranscriptionProvider,
     copy_to_clipboard, post_process,
@@ -82,13 +80,16 @@ impl Service {
     }
 
     /// Run the service main loop
+    ///
+    /// Uses `tokio::select!` for event-driven operation instead of polling,
+    /// eliminating CPU usage when idle.
     pub async fn run(
         &self,
-        hotkey_rx: Option<Receiver<HotkeyEvent>>,
+        mut hotkey_rx: Option<UnboundedReceiver<HotkeyEvent>>,
         push_to_talk: bool,
     ) -> Result<()> {
         // Create IPC server
-        let ipc_server = IpcServer::new().context("Failed to create IPC server")?;
+        let mut ipc_server = IpcServer::new().context("Failed to create IPC server")?;
 
         // Configure model caching for local transcription in listen mode
         // This respects the user's model_memory settings for speed vs memory tradeoff
@@ -100,23 +101,28 @@ impl Service {
         }
 
         loop {
-            // Check for incoming IPC connections (non-blocking)
-            if let Some(mut conn) = ipc_server.try_accept()? {
-                match conn.receive() {
-                    Ok(message) => {
-                        let response = self.handle_message(message).await;
-                        let _ = conn.send(response);
-                    }
-                    Err(e) => {
-                        eprintln!("Error receiving message: {e}");
-                        let _ = conn.send(IpcResponse::Error(e.to_string()));
+            tokio::select! {
+                // Wait for IPC connection
+                Some(mut conn) = ipc_server.accept() => {
+                    match conn.receive() {
+                        Ok(message) => {
+                            let response = self.handle_message(message).await;
+                            let _ = conn.send(response);
+                        }
+                        Err(e) => {
+                            eprintln!("Error receiving message: {e}");
+                            let _ = conn.send(IpcResponse::Error(e.to_string()));
+                        }
                     }
                 }
-            }
 
-            // Check for hotkey events
-            if let Some(ref rx) = hotkey_rx {
-                if let Ok(event) = rx.try_recv() {
+                // Wait for hotkey event (if hotkey is configured)
+                Some(event) = async {
+                    match &mut hotkey_rx {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending().await,
+                    }
+                } => {
                     if push_to_talk {
                         // Push-to-talk mode: press starts, release stops
                         match event {
@@ -135,9 +141,6 @@ impl Service {
                     }
                 }
             }
-
-            // Small sleep to prevent busy waiting
-            sleep(Duration::from_millis(10)).await;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #23 - CPU usage while idle due to 10ms polling loop.

- Replace 10ms polling loop with `tokio::select!` for event-driven operation
- Convert hotkey channel from `std::sync::mpsc` to `tokio::sync::mpsc`
- Make IPC server async by accepting connections in a background thread
- Service now has zero CPU usage when idle (was ~100 wakeups/sec)

## Technical Details

The service loop previously used non-blocking calls with a 10ms sleep:
```rust
loop {
    if let Some(conn) = ipc_server.try_accept()? { ... }
    if let Ok(event) = rx.try_recv() { ... }
    sleep(Duration::from_millis(10)).await;
}
```

Now uses `tokio::select!` to block until there's actual work:
```rust
loop {
    tokio::select! {
        Some(conn) = ipc_server.accept() => { ... }
        Some(event) = hotkey_rx.recv() => { ... }
    }
}
```

## Test plan

- [ ] Run `whis start` and verify it starts normally
- [ ] Check CPU usage with `top` or `htop` - should be ~0% when idle
- [ ] Test `whis toggle` command works via IPC
- [ ] Test direct hotkey mode works (if configured)
- [ ] Test push-to-talk mode works (if configured)