### PR TITLE
fix(cli): preset falls back to global Ollama model when unset

### DIFF
--- a/crates/whis-cli/src/commands/record/pipeline/process.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/process.rs
@@ -86,11 +86,10 @@ fn resolve_post_processor(
             ollama::ensure_ollama_running(&ollama_url)?;
 
             // Model priority: preset > settings
-            let model = if let Some(p) = preset {
-                p.model.clone()
-            } else {
-                settings.services.ollama.model()
-            };
+            let model = preset
+                .as_ref()
+                .and_then(|p| p.model.clone())
+                .or_else(|| settings.services.ollama.model());
 
             if model.is_none() {
                 return Err(anyhow!("Ollama model not configured"));


### PR DESCRIPTION
## Summary

Fix preset model resolution to fall back to global `services.ollama.model` when the preset doesn't specify a model field.

Previously, if a preset existed but had no `model` field, it would error with "Ollama model not configured" even if a global model was set.

## Related Issues

Closes #28