### PR TITLE
fix: improve preset support and centralize post-processor config

### DIFF
--- a/crates/whis-cli/src/args.rs
+++ b/crates/whis-cli/src/args.rs
@@ -130,13 +130,21 @@ pub struct Cli {
 #[allow(clippy::large_enum_variant)]
 pub enum Commands {
     /// Start the background service (uses shortcut_mode from settings)
-    Start,
+    Start {
+        /// Output preset for transcript (run 'whis preset list' to see all)
+        #[arg(long = "as", value_name = "PRESET")]
+        preset: Option<String>,
+    },
 
     /// Stop the background service
     Stop,
 
     /// Restart the background service
-    Restart,
+    Restart {
+        /// Output preset for transcript (run 'whis preset list' to see all)
+        #[arg(long = "as", value_name = "PRESET")]
+        preset: Option<String>,
+    },
 
     /// Check service status
     Status,

--- a/crates/whis-cli/src/commands/record/mod.rs
+++ b/crates/whis-cli/src/commands/record/mod.rs
@@ -97,6 +97,11 @@ pub fn run(config: RecordConfig) -> Result<()> {
         quiet,
     ))?;
 
+    // Print completion after all processing is done
+    if !quiet {
+        println!(" Done.");
+    }
+
     // Phase 4: Output (print, file, or clipboard)
     let output_mode = if config.print {
         pipeline::OutputMode::Print
@@ -326,11 +331,6 @@ async fn progressive_record_and_transcribe(
     }
 
     let text = transcription_task.await??;
-
-    // Print completion message immediately after transcription finishes
-    if !quiet {
-        println!(" Done.");
-    }
 
     Ok(types::TranscriptionResult { text })
 }

--- a/crates/whis-cli/src/commands/record/pipeline/output.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/output.rs
@@ -148,7 +148,7 @@ pub fn output(
             let settings = Settings::load();
             copy_to_clipboard(&formatted, settings.ui.clipboard_backend)?;
             if !quiet && io::stdout().is_terminal() {
-                println!("Copied to clipboard!");
+                eprintln!("Copied to clipboard!");
             }
         }
     }

--- a/crates/whis-cli/src/commands/record/pipeline/process.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/process.rs
@@ -1,9 +1,7 @@
 //! Post-processing pipeline phase
 
-use anyhow::{Result, anyhow};
-use whis_core::{
-    DEFAULT_POST_PROCESSING_PROMPT, PostProcessor, Preset, Settings, ollama, post_process,
-};
+use anyhow::Result;
+use whis_core::{PostProcessor, Preset, Settings, post_process, resolve_post_processor_config};
 
 use super::super::types::{ProcessedResult, TranscriptionResult};
 use crate::app;
@@ -26,7 +24,7 @@ pub async fn process(
     if config.enabled || config.preset.is_some() {
         let settings = Settings::load();
         let (processor, api_key, model, prompt) =
-            resolve_post_processor(&config.preset, &settings)?;
+            resolve_post_processor_config(&config.preset, &settings)?;
 
         // Re-warm Ollama model (in case it unloaded during long recording > keep_alive timeout)
         if processor == PostProcessor::Ollama && model.is_some() {
@@ -43,90 +41,4 @@ pub async fn process(
     }
 
     Ok(ProcessedResult { text })
-}
-
-/// Resolve post-processing configuration from settings and preset
-fn resolve_post_processor(
-    preset: &Option<Preset>,
-    settings: &Settings,
-) -> Result<(PostProcessor, String, Option<String>, String)> {
-    // Determine which post-processor to use
-    let processor = if let Some(p) = preset {
-        if let Some(post_processor_str) = &p.post_processor {
-            post_processor_str
-                .parse()
-                .unwrap_or(settings.post_processing.processor.clone())
-        } else {
-            settings.post_processing.processor.clone()
-        }
-    } else {
-        settings.post_processing.processor.clone()
-    };
-
-    // Determine prompt: preset > settings > default
-    let prompt = if let Some(p) = preset {
-        p.prompt.clone()
-    } else {
-        settings
-            .post_processing
-            .prompt
-            .clone()
-            .unwrap_or_else(|| DEFAULT_POST_PROCESSING_PROMPT.to_string())
-    };
-
-    // Get API key/URL and model based on processor type
-    match processor {
-        PostProcessor::Ollama => {
-            // Start Ollama if not running
-            let ollama_url = settings
-                .services
-                .ollama
-                .url()
-                .ok_or_else(|| anyhow!("Ollama URL not configured"))?;
-            ollama::ensure_ollama_running(&ollama_url)?;
-
-            // Model priority: preset > settings
-            let model = preset
-                .as_ref()
-                .and_then(|p| p.model.clone())
-                .or_else(|| settings.services.ollama.model());
-
-            if model.is_none() {
-                return Err(anyhow!("Ollama model not configured"));
-            }
-
-            Ok((PostProcessor::Ollama, ollama_url, model, prompt))
-        }
-        PostProcessor::OpenAI => {
-            let api_key = settings
-                .post_processing
-                .api_key(&settings.transcription.api_keys)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "OpenAI API key not configured. Set it with: whis config --openai-api-key <key>"
-                    )
-                })?;
-
-            // Model from preset if available
-            let model = preset.as_ref().and_then(|p| p.model.clone());
-
-            Ok((PostProcessor::OpenAI, api_key, model, prompt))
-        }
-        PostProcessor::Mistral => {
-            let api_key = settings
-                .post_processing
-                .api_key(&settings.transcription.api_keys)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "Mistral API key not configured. Set it with: whis config --mistral-api-key <key>"
-                    )
-                })?;
-
-            // Model from preset if available
-            let model = preset.as_ref().and_then(|p| p.model.clone());
-
-            Ok((PostProcessor::Mistral, api_key, model, prompt))
-        }
-        PostProcessor::None => Err(anyhow!("Post-processing not configured. Run: whis setup")),
-    }
 }

--- a/crates/whis-cli/src/commands/record/pipeline/process.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/process.rs
@@ -86,11 +86,10 @@ fn resolve_post_processor(
             ollama::ensure_ollama_running(&ollama_url)?;
 
             // Model priority: preset > settings
-            let model = if let Some(p) = preset {
-                p.model.clone()
-            } else {
-                settings.services.ollama.model()
-            };
+            let model = preset
+                .as_ref()
+                .and_then(|p| p.model.clone())
+                .or_else(|| settings.services.ollama.model());
 
             if model.is_none() {
                 return Err(anyhow!("Ollama model not configured"));

--- a/crates/whis-cli/src/commands/restart.rs
+++ b/crates/whis-cli/src/commands/restart.rs
@@ -1,7 +1,7 @@
 use crate::ipc;
 use anyhow::Result;
 
-pub fn run() -> Result<()> {
+pub fn run(preset_name: Option<String>) -> Result<()> {
     // Stop the service if running
     if ipc::is_service_running() {
         let mut client = ipc::IpcClient::connect()?;
@@ -12,6 +12,6 @@ pub fn run() -> Result<()> {
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
-    // Start the service (uses settings for shortcut_mode)
-    crate::commands::start::run()
+    // Start the service with optional preset
+    crate::commands::start::run(preset_name)
 }

--- a/crates/whis-cli/src/main.rs
+++ b/crates/whis-cli/src/main.rs
@@ -26,9 +26,9 @@ fn run() -> Result<()> {
     whis_core::set_verbose(cli.verbose);
 
     match cli.command {
-        Some(args::Commands::Start) => commands::start::run(),
+        Some(args::Commands::Start { preset }) => commands::start::run(preset),
         Some(args::Commands::Stop) => commands::stop::run(),
-        Some(args::Commands::Restart) => commands::restart::run(),
+        Some(args::Commands::Restart { preset }) => commands::restart::run(preset),
         Some(args::Commands::Status) => commands::status::run(),
         Some(args::Commands::Toggle) => commands::toggle::run(),
         Some(args::Commands::Config {

--- a/crates/whis-core/src/lib.rs
+++ b/crates/whis-core/src/lib.rs
@@ -40,7 +40,7 @@ pub use transcription::progressive_transcribe_local;
 pub use transcription::{
     DEFAULT_POST_PROCESSING_PROMPT, PostProcessConfig, PostProcessor, WarmupConfig,
     clear_warmup_cache, post_process, preload_ollama, progressive_transcribe_cloud,
-    warmup_configured,
+    resolve_post_processor_config, warmup_configured,
 };
 
 // Re-export provider types
@@ -103,6 +103,7 @@ pub mod preset {
 pub mod post_processing {
     pub use crate::transcription::{
         DEFAULT_POST_PROCESSING_PROMPT, PostProcessConfig, PostProcessor, post_process,
+        resolve_post_processor_config,
     };
 }
 

--- a/crates/whis-core/src/transcription/mod.rs
+++ b/crates/whis-core/src/transcription/mod.rs
@@ -20,6 +20,7 @@ pub use ollama::{
 pub use ollama_manager::{clear_warmup_cache, preload_ollama};
 pub use post_processing::{
     DEFAULT_POST_PROCESSING_PROMPT, PostProcessConfig, PostProcessor, post_process,
+    resolve_post_processor_config,
 };
 pub use transcribe::progressive_transcribe_cloud;
 #[cfg(feature = "local-transcription")]

--- a/crates/whis-desktop/src/shortcuts/mod.rs
+++ b/crates/whis-desktop/src/shortcuts/mod.rs
@@ -82,7 +82,10 @@ pub fn setup_shortcuts(app: &tauri::App) {
 
     let compositor_name = capability.platform_info.compositor.display_name();
     let platform_name = platform_display_name(&capability.platform_info.platform);
-    println!("Detected environment: {} ({})", compositor_name, platform_name);
+    println!(
+        "Detected environment: {} ({})",
+        compositor_name, platform_name
+    );
 
     match capability.backend {
         ShortcutBackend::TauriPlugin => {


### PR DESCRIPTION
## Summary

- Centralize `resolve_post_processor_config()` in `whis-core` as single source of truth
- Add `--as <PRESET>` flag to `whis start` and `whis restart` commands
- Validate post-processing config at startup (fail fast on missing Ollama model)
- Log post-processing errors to stderr instead of silent fallback
- Fix timing of "Done." message (now prints after post-processing)

## Changes

| File | Impact |
|------|--------|
| `whis-core/src/transcription/post_processing.rs` | Added `resolve_post_processor_config()` |
| `whis-core/src/lib.rs` | Re-export new function |
| `whis-cli/src/commands/record/pipeline/process.rs` | Use shared function, removed duplication |
| `whis-cli/src/service.rs` | Use shared function, log errors to stderr |
| `whis-cli/src/commands/start.rs` | Early validation, accept preset |
| `whis-cli/src/args.rs` | Add preset field to Start/Restart commands |
| `whis-cli/src/commands/restart.rs` | Forward preset to start |

## Test plan

- [ ] `whis start --as bad-preset` fails immediately with clear error
- [ ] `whis start --as valid-preset` works correctly
- [ ] `whis restart --as preset` restarts with preset applied
- [ ] Post-processing errors are logged to stderr in service mode