### PR TITLE
feat(settings): separate CLI and desktop config storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7277,6 +7277,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-store",
  "tokio",
  "whis-core",
  "zbus",

--- a/crates/whis-cli/src/app.rs
+++ b/crates/whis-cli/src/app.rs
@@ -20,10 +20,10 @@ pub fn load_transcription_config_with_language(
     language_override: Option<String>,
 ) -> Result<TranscriptionConfig> {
     // Check if settings file exists (fresh install detection)
-    let settings_path = Settings::path();
+    let settings_path = Settings::cli_path();
     let is_fresh_install = !settings_path.exists();
 
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
     let provider = settings.transcription.provider.clone();
 
     // Use override if provided, otherwise use configured language

--- a/crates/whis-cli/src/commands/config.rs
+++ b/crates/whis-cli/src/commands/config.rs
@@ -33,7 +33,7 @@ const VALID_KEYS: &[&str] = &[
 pub fn run(key: Option<String>, value: Option<String>, list: bool, path: bool) -> Result<()> {
     // Handle --path flag
     if path {
-        println!("{}", Settings::path().display());
+        println!("{}", Settings::cli_path().display());
         return Ok(());
     }
 
@@ -74,7 +74,7 @@ pub fn run(key: Option<String>, value: Option<String>, list: bool, path: bool) -
 }
 
 fn set_config(key: &str, value: &str) -> Result<()> {
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
     let value_trimmed = value.trim();
 
     match key {
@@ -260,12 +260,12 @@ fn set_config(key: &str, value: &str) -> Result<()> {
         _ => unreachable!("Key validation should prevent this"),
     }
 
-    settings.save()?;
+    settings.save_cli()?;
     Ok(())
 }
 
 fn get_config(key: &str) -> Result<()> {
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
 
     match key {
         "provider" => println!("{}", settings.transcription.provider),
@@ -343,9 +343,9 @@ fn print_api_key(settings: &Settings, provider: &TranscriptionProvider) {
 }
 
 fn show_all_settings() -> Result<()> {
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
 
-    println!("Configuration file: {}", Settings::path().display());
+    println!("Configuration file: {}", Settings::cli_path().display());
     println!();
 
     println!("[Transcription]");

--- a/crates/whis-cli/src/commands/record/mod.rs
+++ b/crates/whis-cli/src/commands/record/mod.rs
@@ -143,7 +143,7 @@ async fn progressive_record_and_transcribe(
     let mut recorder = AudioRecorder::new()?;
 
     // Configure VAD (disabled for realtime - they handle silence detection)
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
     let vad_enabled = settings.ui.vad.enabled && !mic_config.no_vad && !is_realtime;
     recorder.set_vad(vad_enabled, settings.ui.vad.threshold);
 
@@ -158,7 +158,7 @@ async fn progressive_record_and_transcribe(
 
         // Load settings once for post-processing config
         let (post_processor, post_processor_api_key) = if mic_config.will_post_process {
-            let settings = Settings::load();
+            let settings = Settings::load_cli();
             let processor = match &settings.post_processing.processor {
                 whis_core::PostProcessor::None => None,
                 p => Some(p.to_string()),
@@ -264,7 +264,7 @@ async fn progressive_record_and_transcribe(
                 #[cfg(feature = "local-transcription")]
                 if provider == TranscriptionProvider::LocalParakeet {
                     // Local Parakeet progressive transcription
-                    let model_path = Settings::load()
+                    let model_path = Settings::load_cli()
                         .transcription
                         .parakeet_model_path()
                         .ok_or_else(|| anyhow::anyhow!("Parakeet model path not configured"))?;
@@ -339,7 +339,7 @@ async fn progressive_record_and_transcribe(
 fn preload_models(config: &modes::MicrophoneConfig) {
     #[cfg(feature = "local-transcription")]
     {
-        let settings = whis_core::Settings::load();
+        let settings = whis_core::Settings::load_cli();
 
         // Preload the configured local model (Whisper OR Parakeet, not both)
         match config.provider {
@@ -359,7 +359,7 @@ fn preload_models(config: &modes::MicrophoneConfig) {
 
     // Preload Ollama if post-processing enabled
     if config.will_post_process {
-        let settings = whis_core::Settings::load();
+        let settings = whis_core::Settings::load_cli();
         if settings.post_processing.processor == whis_core::PostProcessor::Ollama {
             settings.services.ollama.preload();
         }
@@ -388,7 +388,7 @@ async fn transcribe_file(
     let text = match &transcription_config.provider {
         #[cfg(feature = "local-transcription")]
         TranscriptionProvider::LocalParakeet => {
-            let model_path = whis_core::Settings::load()
+            let model_path = whis_core::Settings::load_cli()
                 .transcription
                 .parakeet_model_path()
                 .ok_or_else(|| anyhow::anyhow!("Parakeet model path not configured"))?;

--- a/crates/whis-cli/src/commands/record/pipeline/output.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/output.rs
@@ -145,7 +145,7 @@ pub fn output(
             }
         }
         OutputMode::Clipboard => {
-            let settings = Settings::load();
+            let settings = Settings::load_cli();
 
             // Handle output based on configured method
             match settings.ui.output_method {

--- a/crates/whis-cli/src/commands/record/pipeline/process.rs
+++ b/crates/whis-cli/src/commands/record/pipeline/process.rs
@@ -22,7 +22,7 @@ pub async fn process(
 
     // If post-processing is enabled OR a preset is provided, apply LLM processing
     if config.enabled || config.preset.is_some() {
-        let settings = Settings::load();
+        let settings = Settings::load_cli();
         let (processor, api_key, model, prompt) =
             resolve_post_processor_config(&config.preset, &settings)?;
 

--- a/crates/whis-cli/src/commands/setup/cloud.rs
+++ b/crates/whis-cli/src/commands/setup/cloud.rs
@@ -73,7 +73,7 @@ pub fn prompt_and_validate_key(provider: &TranscriptionProvider) -> Result<Strin
 /// Streamlined cloud transcription setup (no post-processing config)
 /// Used by the unified wizard
 pub fn setup_transcription_cloud() -> Result<()> {
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
     let providers = cloud_providers();
 
     // Build provider display items: with markers for selection, just name for confirmation
@@ -171,7 +171,7 @@ pub fn setup_transcription_cloud() -> Result<()> {
     }
 
     settings.transcription.provider = provider;
-    settings.save()?;
+    settings.save_cli()?;
 
     Ok(())
 }

--- a/crates/whis-cli/src/commands/setup/local.rs
+++ b/crates/whis-cli/src/commands/setup/local.rs
@@ -22,7 +22,7 @@ use whis_core::model::{ModelType, ParakeetModel, WhisperModel};
 /// Streamlined local transcription setup (no post-processing config)
 /// Used by the unified wizard
 pub fn setup_transcription_local() -> Result<()> {
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
 
     // Determine current engine and show with [current] marker during selection
     let current_engine = match settings.transcription.provider {
@@ -206,7 +206,7 @@ pub fn setup_transcription_local() -> Result<()> {
         }
         _ => {}
     }
-    settings.save()?;
+    settings.save_cli()?;
 
     Ok(())
 }

--- a/crates/whis-cli/src/commands/setup/mod.rs
+++ b/crates/whis-cli/src/commands/setup/mod.rs
@@ -50,7 +50,7 @@ pub fn run() -> Result<()> {
 
 /// Unified setup wizard - guides user through all configuration
 fn setup_wizard() -> Result<()> {
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
 
     // Default to current provider type (Local if using local, else Cloud)
     let default = match settings.transcription.provider {
@@ -88,7 +88,7 @@ fn setup_wizard() -> Result<()> {
 
 /// Setup shortcut mode (system or direct)
 fn setup_shortcut_step() -> Result<()> {
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
 
     let items = vec!["System shortcut", "Direct capture"];
     let default = if settings.shortcuts.cli_mode == CliShortcutMode::Direct {
@@ -102,7 +102,7 @@ fn setup_shortcut_step() -> Result<()> {
         0 => {
             // System mode
             settings.shortcuts.cli_mode = CliShortcutMode::System;
-            settings.save()?;
+            settings.save_cli()?;
 
             interactive::info("Add a shortcut in desktop settings: whis toggle");
         }
@@ -118,7 +118,7 @@ fn setup_shortcut_step() -> Result<()> {
                 match hotkey::validate(&input) {
                     Ok(normalized) => {
                         settings.shortcuts.cli_key = input;
-                        settings.save()?;
+                        settings.save_cli()?;
                         break normalized;
                     }
                     Err(_) => {
@@ -171,7 +171,7 @@ fn setup_audio_device_step() -> Result<()> {
     }
 
     // Find current selection for default highlight
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
     let default_idx = settings
         .ui
         .microphone_device
@@ -189,7 +189,7 @@ fn setup_audio_device_step() -> Result<()> {
         Some(devices[choice - 1].name.clone())
     };
 
-    settings.save()?;
+    settings.save_cli()?;
     Ok(())
 }
 

--- a/crates/whis-cli/src/commands/setup/post_processing.rs
+++ b/crates/whis-cli/src/commands/setup/post_processing.rs
@@ -205,7 +205,7 @@ pub fn select_ollama_model(url: &str, current_model: Option<&str>) -> Result<Str
 
 /// Independent post-processing step (called after transcription setup in wizard)
 pub fn setup_post_processing_step(_prefer_cloud: bool) -> Result<()> {
-    let mut settings = Settings::load();
+    let mut settings = Settings::load_cli();
 
     // Default to current processor setting
     let default = match settings.post_processing.processor {
@@ -249,7 +249,7 @@ pub fn setup_post_processing_step(_prefer_cloud: bool) -> Result<()> {
         _ => unreachable!(),
     }
 
-    settings.save()?;
+    settings.save_cli()?;
     Ok(())
 }
 

--- a/crates/whis-cli/src/commands/start.rs
+++ b/crates/whis-cli/src/commands/start.rs
@@ -14,7 +14,7 @@ pub fn run(autotype: bool, preset_name: Option<String>) -> Result<()> {
     }
 
     // Load settings and transcription configuration
-    let settings = Settings::load();
+    let settings = Settings::load_cli();
 
     // Determine output method override from CLI flag
     let output_method_override = if autotype {

--- a/crates/whis-cli/src/service.rs
+++ b/crates/whis-cli/src/service.rs
@@ -103,7 +103,7 @@ impl Service {
         // This respects the user's model_memory settings for speed vs memory tradeoff
         #[cfg(feature = "local-transcription")]
         {
-            let settings = whis_core::Settings::load();
+            let settings = whis_core::Settings::load_cli();
             let keep_loaded = settings.ui.model_memory.keep_model_loaded;
             self.provider.set_keep_loaded(keep_loaded);
         }
@@ -284,7 +284,7 @@ impl Service {
         let mut recorder = AudioRecorder::new()?;
 
         // Configure VAD from settings
-        let settings = Settings::load();
+        let settings = Settings::load_cli();
         #[cfg(feature = "vad")]
         {
             recorder.set_vad(settings.ui.vad.enabled, settings.ui.vad.threshold);
@@ -338,7 +338,7 @@ impl Service {
             #[cfg(feature = "local-transcription")]
             if provider == TranscriptionProvider::LocalParakeet {
                 // Local Parakeet progressive transcription
-                let model_path = Settings::load()
+                let model_path = Settings::load_cli()
                     .transcription
                     .parakeet_model_path()
                     .ok_or_else(|| anyhow::anyhow!("Parakeet model path not configured"))?;
@@ -424,7 +424,7 @@ impl Service {
             .context("Failed to join transcription task")??;
 
         // Apply post-processing if enabled or preset is provided
-        let settings = Settings::load();
+        let settings = Settings::load_cli();
         let final_text = if settings.post_processing.enabled || self.preset.is_some() {
             match resolve_post_processor_config(&self.preset, &settings) {
                 Ok((processor, api_key, model, prompt)) => {

--- a/crates/whis-desktop/Cargo.toml
+++ b/crates/whis-desktop/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-process = "2.3"
 futures-util = "0.3"
 image = "0.25"
 tauri-plugin-single-instance = "2.3.6"
+tauri-plugin-store = "2.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18"

--- a/crates/whis-desktop/capabilities/default.json
+++ b/crates/whis-desktop/capabilities/default.json
@@ -14,6 +14,10 @@
     "global-shortcut:allow-register",
     "global-shortcut:allow-unregister",
     "global-shortcut:allow-unregister-all",
-    "process:allow-restart"
+    "process:allow-restart",
+    "store:allow-get",
+    "store:allow-set",
+    "store:allow-save",
+    "store:allow-load"
   ]
 }

--- a/crates/whis-desktop/src/commands/bubble.rs
+++ b/crates/whis-desktop/src/commands/bubble.rs
@@ -4,6 +4,7 @@
 
 use tauri::{AppHandle, Manager};
 
+use super::save_settings_to_store;
 use crate::state::AppState;
 
 /// Toggle recording from bubble click
@@ -44,14 +45,14 @@ pub fn bubble_move_by(app: AppHandle, dx: f64, dy: f64) -> Result<(), String> {
 #[tauri::command]
 pub fn bubble_save_position(app: AppHandle, x: f64, y: f64) -> Result<(), String> {
     let state = app.state::<AppState>();
-    state.with_settings_mut(|s| {
+
+    // Update state and get clone for persistence
+    let settings_clone = state.with_settings_mut(|s| {
         s.ui.bubble.custom_position = Some((x, y));
+        s.clone()
     });
-    // Persist to disk
-    if let Err(e) = state.with_settings(|s| s.save()) {
-        eprintln!("Failed to save bubble position: {e}");
-    }
-    Ok(())
+
+    save_settings_to_store(&app, &settings_clone)
 }
 
 /// Check if bubble drag-and-drop is supported on this platform.

--- a/crates/whis-desktop/src/commands/mod.rs
+++ b/crates/whis-desktop/src/commands/mod.rs
@@ -23,6 +23,24 @@
 //! └── mod.rs             - Public API (this file)
 //! ```
 
+use tauri::AppHandle;
+use tauri_plugin_store::StoreExt;
+use whis_core::Settings;
+
+/// Save settings to Tauri store (shared helper for all commands)
+pub(crate) fn save_settings_to_store(app: &AppHandle, settings: &Settings) -> Result<(), String> {
+    let store = app
+        .store("settings.json")
+        .map_err(|e| format!("Failed to open store: {e}"))?;
+    store.set(
+        "settings",
+        serde_json::to_value(settings).map_err(|e| format!("Failed to serialize settings: {e}"))?,
+    );
+    store
+        .save()
+        .map_err(|e| format!("Failed to save settings: {e}"))
+}
+
 pub mod bubble;
 pub mod models;
 pub mod ollama;

--- a/crates/whis-desktop/src/commands/settings.rs
+++ b/crates/whis-desktop/src/commands/settings.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides Tauri commands for getting, saving, and validating application settings.
 
+use super::save_settings_to_store;
 use crate::state::AppState;
 use tauri::{AppHandle, State};
 use whis_core::{
@@ -57,8 +58,10 @@ pub async fn save_settings(
     {
         let mut state_settings = state.settings.lock().unwrap();
         *state_settings = settings.clone();
-        state_settings.save().map_err(|e| e.to_string())?;
     }
+
+    // Save to Tauri store
+    save_settings_to_store(&app, &settings)?;
 
     // Clear cached transcription config if provider or API key changed
     if config_changed {


### PR DESCRIPTION
## Summary

Separates configuration storage for CLI and desktop applications, allowing both to run simultaneously without conflicts.

| Application | Storage Location |
|-------------|------------------|
| CLI | `~/.config/whis-cli/settings.json` (filesystem) |
| Desktop | Tauri plugin-store (platform app data directory) |

## Changes

### whis-core
- Renamed `Settings` methods to CLI-specific: `load()` → `load_cli()`, `save()` → `save_cli()`, `path()` → `cli_path()`
- Updated module documentation for the new architecture

### whis-cli (11 files)
- Updated all 22 `Settings::load()` calls to `Settings::load_cli()`
- Updated all 7 `save()` calls to `save_cli()`
- Updated `path()` calls to `cli_path()`

### whis-desktop
- Added `tauri-plugin-store` dependency for persistent storage
- Added store permissions to capabilities
- Created `load_settings_from_store()` helper for startup
- Created shared `save_settings_to_store()` helper for all commands
- Updated presets, bubble, and settings commands to use the store
- Replaced direct `Settings::load()` with `AppState` in system commands
- Consolidated lock acquisitions in recording control for better performance
- Replaced `println!` with proper `info!` logging

## Why

Previously, CLI and desktop shared the same config file (`~/.config/whis/settings.json`). This caused conflicts when both applications were running simultaneously—each would overwrite the other's settings.

Now each application manages its own configuration independently:
- CLI uses the filesystem directly (appropriate for a command-line tool)
- Desktop uses Tauri's plugin-store (integrates with platform conventions)

## Test Plan

- [ ] CLI: `whis config --path` shows `~/.config/whis-cli/settings.json`
- [ ] CLI: `whis config provider deepgram` creates/updates file at new path
- [ ] Desktop: Settings persist across app restarts
- [ ] Both apps can run simultaneously without config conflicts

Closes #25