### PR TITLE
make system close behave the same as close button

### DIFF
--- a/crates/whis-desktop/ui/src/App.vue
+++ b/crates/whis-desktop/ui/src/App.vue
@@ -96,10 +96,7 @@ onMounted(async () => {
   })
 
   // Listen for window close event (Alt+F4, system close, etc.)
-  await listen('window-close-requested', async () => {
-    await settingsStore.flush()
-    await getCurrentWindow().close()
-  })
+  await listen('window-close-requested', closeWindow)
 })
 </script>
 


### PR DESCRIPTION
For me (wayland-linux), sending close event from the compositor (Alt+f4/right click on the taskbar icon), does not close the window, but triggers an infinite flow `window-close-requested` events.

This change makes the close event take the same path as pressing the button, which would make sense even if the previous method worked.

